### PR TITLE
Fix  error: redeclaration of ‘T* luabind::memory_allocator<T>::alloca…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ doc/*.html
 doc/version.rst
 build
 lua
+/CMakeFiles
+/doc
+/src/CMakeFiles
+/cmake
+/test/CMakeFiles
+/test
+/src

--- a/luabind/memory_allocator.hpp
+++ b/luabind/memory_allocator.hpp
@@ -97,7 +97,7 @@ typename MEMORY_ALLOCATOR::const_pointer MEMORY_ALLOCATOR::address(const_referen
 }
 
 TEMPLATE_SPECIALIZATION
-typename MEMORY_ALLOCATOR::pointer MEMORY_ALLOCATOR::allocate(size_type n, void const* p = 0) const
+typename MEMORY_ALLOCATOR::pointer MEMORY_ALLOCATOR::allocate(size_type n, void const* p) const
 {
     pointer result = (pointer)detail::call_allocator(p, n * sizeof(T));
     if (!n)


### PR DESCRIPTION
Fixed error on linux. Compiler gcc version 5.3.0 20151204 (Ubuntu 5.3.0-3ubuntu1~14.04) 

```C++
Scanning dependencies of target luabind
[  1%] Building CXX object src/CMakeFiles/luabind.dir/class.cpp.o
In file included from /home/razor/Documents/luabind-deboostified/luabind/types.hpp:12:0,
                 from /home/razor/Documents/luabind-deboostified/luabind/config.hpp:128,
                 from /home/razor/Documents/luabind-deboostified/src/class.cpp:27:
/home/razor/Documents/luabind-deboostified/luabind/memory_allocator.hpp:100:95: error: redeclaration of ‘T* luabind::memory_allocator<T>::allocate(luabind::memory_allocator<T>::size_type, const void*) const’ may not have default arguments [-fpermissive]
 typename MEMORY_ALLOCATOR::pointer MEMORY_ALLOCATOR::allocate(size_type n, void const* p = 0) const
                                                                                               ^
make[2]: *** [src/CMakeFiles/luabind.dir/class.cpp.o] Error 1
```