### PR TITLE
Destroy pointer to type_info of class when dll is unloading.

### DIFF
--- a/luabind/class.hpp
+++ b/luabind/class.hpp
@@ -507,7 +507,7 @@ namespace luabind {
 	private:
 		void init()
 		{
-			class_base::init(typeid(T), detail::registered_class<T>::id, typeid(WrapperType), detail::registered_class<WrapperType>::id);
+			class_base::init(typeid(T), detail::registered_class<T>::id.get(), typeid(WrapperType), detail::registered_class<WrapperType>::id.get());
 			add_wrapper_cast((WrapperType*)0);
 			generate_baseclass_list();
 		}
@@ -519,7 +519,7 @@ namespace luabind {
 		template <class Src, class Target>
 		void add_downcast(Src*, Target*, std::true_type)
 		{
-			add_cast(detail::registered_class<Src>::id, detail::registered_class<Target>::id, detail::dynamic_cast_<Src, Target>::execute);
+			add_cast(detail::registered_class<Src>::id.get(), detail::registered_class<Target>::id.get(), detail::dynamic_cast_<Src, Target>::execute);
 		}
 
 		template <class Src, class Target>
@@ -533,7 +533,7 @@ namespace luabind {
 		void gen_base_info(bases<Class0, Classes...>)
 		{
 			add_base(typeid(Class0), detail::static_cast_<T, Class0>::execute);
-			add_cast(detail::registered_class<T>::id, detail::registered_class<Class0>::id, detail::static_cast_<T, Class0>::execute);
+			add_cast(detail::registered_class<T>::id.get(), detail::registered_class<Class0>::id.get(), detail::static_cast_<T, Class0>::execute);
 			add_downcast((Class0*)0, (T*)0, std::is_polymorphic<Class0>());
 			gen_base_info(bases<Classes...>());
 		}
@@ -555,7 +555,7 @@ namespace luabind {
 		template <class U>
 		void add_wrapper_cast(U*)
 		{
-			add_cast(detail::registered_class<U>::id, detail::registered_class<T>::id, detail::static_cast_<U, T>::execute);
+			add_cast(detail::registered_class<U>::id.get(), detail::registered_class<T>::id.get(), detail::static_cast_<U, T>::execute);
 			add_downcast((T*)0, (U*)0, std::is_polymorphic<T>());
 		}
 

--- a/luabind/detail/constructor.hpp
+++ b/luabind/detail/constructor.hpp
@@ -42,7 +42,7 @@ namespace luabind {
 
 				void* storage = self->allocate(sizeof(holder_type));
 
-				self->set_instance(new (storage) holder_type(std::move(ptr), registered_class<T>::id, naked_ptr));
+				self->set_instance(new (storage) holder_type(std::move(ptr), registered_class<T>::id.get(), naked_ptr));
 			}
 		};
 

--- a/luabind/detail/conversion_policies/pointer_converter.hpp
+++ b/luabind/detail/conversion_policies/pointer_converter.hpp
@@ -74,7 +74,7 @@ namespace luabind {
 				if(obj->is_const())
 					return no_match;
 
-				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id);
+				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id.get());
 				result = s.first;
 				return s.second;
 			}
@@ -124,7 +124,7 @@ namespace luabind {
 				if(lua_isnil(L, index)) return 0;
 				object_rep* obj = get_instance(L, index);
 				if(obj == 0) return no_match; // if the type is not one of our own registered types, classify it as a non-match
-				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id);
+				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id.get());
 				if(s.second >= 0 && !obj->is_const())
 					s.second += 10;
 				result = s.first;

--- a/luabind/detail/conversion_policies/reference_converter.hpp
+++ b/luabind/detail/conversion_policies/reference_converter.hpp
@@ -61,7 +61,7 @@ namespace luabind {
 				if(obj->is_const())
 					return no_match;
 
-				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id);
+				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id.get());
 				result = s.first;
 				return s.second;
 			}
@@ -104,7 +104,7 @@ namespace luabind {
 				object_rep* obj = get_instance(L, index);
 				if(obj == 0) return no_match; // if the type is not one of our own registered types, classify it as a non-match
 
-				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id);
+				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id.get());
 				if(s.second >= 0 && !obj->is_const())
 					s.second += 10;
 				result = s.first;

--- a/luabind/detail/conversion_policies/value_converter.hpp
+++ b/luabind/detail/conversion_policies/value_converter.hpp
@@ -63,7 +63,7 @@ namespace luabind {
 				object_rep* obj = get_instance(L, index);
 				if(obj == 0) return no_match;
 
-				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id);
+				std::pair<void*, int> s = obj->get_instance(registered_class<T>::id.get());
 				result = s.first;
 				return s.second;
 			}

--- a/luabind/detail/instance_holder.hpp
+++ b/luabind/detail/instance_holder.hpp
@@ -48,7 +48,7 @@ namespace luabind {
 			std::pair<void*, int> get(cast_graph const& casts, class_id target) const override
 			{
 				// if somebody wants the smart-ptr, he can get a reference to it
-				if(target == registered_class<P>::id) return std::pair<void*, int>(&this->p, 0);
+				if(target == registered_class<P>::id.get()) return std::pair<void*, int>(&this->p, 0);
 
 				void* naked_ptr = const_cast<void*>(static_cast<void const*>(weak ? weak : get_pointer(p)));
 				if(!naked_ptr) return std::pair<void*, int>(nullptr, 0);
@@ -56,7 +56,7 @@ namespace luabind {
 				using pointee_type = typename std::remove_cv<typename std::remove_reference<decltype(*get_pointer(p))>::type>::type;
 
 				return casts.cast(naked_ptr,
-					registered_class< pointee_type >::id,
+					registered_class< pointee_type >::id.get(),
 					target, dynamic_id, dynamic_ptr);
 			}
 
@@ -98,7 +98,7 @@ namespace luabind {
 
 			std::pair<void*, int> get(cast_graph const& casts, class_id target) const override
 			{
-				const auto this_id = registered_class<ValueType>::id;
+				const auto this_id = registered_class<ValueType>::id.get();
 				void* const naked_ptr = const_cast<void*>((const void*)&val_);
 				if(target == this_id) return std::pair<void*, int>(naked_ptr, 0);
 				return casts.cast(naked_ptr, this_id, target, this_id, naked_ptr);
@@ -136,13 +136,13 @@ namespace luabind {
 
 			std::pair<void*, int> get(cast_graph const& casts, class_id target) const override
 			{
-				const auto value_id = registered_class<ValueType>::id;
+				const auto value_id = registered_class<ValueType>::id.get();
 				void* const naked_value_ptr = const_cast<void*>((const void*)&val_);
 				if(target == value_id) return std::pair<void*, int>(naked_value_ptr, 0);
 				// If we were to support automatic pointer conversion, this would be the place
 
 				using pointee_type = typename std::remove_cv<typename std::remove_reference<decltype(*get_pointer(val_))>::type >::type;
-				const auto pointee_id = registered_class< pointee_type >::id;
+				const auto pointee_id = registered_class< pointee_type >::id.get();
 				void* const naked_pointee_ptr = const_cast<void*>((const void*)get_pointer(val_));
 				return casts.cast(naked_pointee_ptr, pointee_id, target, dynamic_id_, dynamic_ptr_);
 			}

--- a/luabind/detail/make_instance.hpp
+++ b/luabind/detail/make_instance.hpp
@@ -25,7 +25,7 @@ namespace luabind {
 		template <class T>
 		std::pair<class_id, void*> get_dynamic_class_aux(lua_State*, T const* p, std::false_type)
 		{
-			return std::make_pair(registered_class<T>::id, (void*)p);
+			return std::make_pair(registered_class<T>::id.get(), (void*)p);
 		}
 
 		template <class T>
@@ -37,7 +37,7 @@ namespace luabind {
 		template <class T>
 		class_rep* get_pointee_class(class_map const& classes, T*)
 		{
-			return classes.get(registered_class<T>::id);
+			return classes.get(registered_class<T>::id.get());
 		}
 
 		template <class P>
@@ -132,7 +132,7 @@ namespace luabind {
 		template< typename ValueType >
 		void make_value_instance(lua_State* L, ValueType&& val, std::false_type /* smart ptr */)
 		{
-			const auto value_type_id = detail::registered_class<ValueType>::id;
+			const auto value_type_id = detail::registered_class<ValueType>::id.get();
 			class_rep* cls = get_pointee_class(L, &val, value_type_id);
 
 			if(!cls) {

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -130,7 +130,7 @@ namespace luabind {
 
 			classes.put(m_id, crep);
 
-			bool const has_wrapper = m_wrapper_id != registered_class<null_type>::id;
+			bool const has_wrapper = m_wrapper_id != registered_class<null_type>::id.get();
 
 			if(has_wrapper)
 				classes.put(m_wrapper_id, crep);


### PR DESCRIPTION
DLL should be unloaded only after all dlls that use luabind are loaded.