### PR TITLE
Fix generator expression used for shared libs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
 	PRIVATE
-	$<$<BOOL:LUABIND_BUILD_SHARED>:LUABIND_DYNAMIC_LINK>
+	$<$<BOOL:${LUABIND_BUILD_SHARED}>:LUABIND_DYNAMIC_LINK>
 )
 
 target_compile_options(${PROJECT_NAME}


### PR DESCRIPTION
The generator expression that adds the LUABIND_DYNAMIC_LINK compile
define was coercing the literal value "LUABIND_BUILD_SHARED" to a
boolean before.