### PR TITLE
Remove use of deprecated `std::iterator`

### DIFF
--- a/luabind/detail/crtp_iterator.hpp
+++ b/luabind/detail/crtp_iterator.hpp
@@ -1,18 +1,20 @@
 ﻿#ifndef LUABIND_CRTP_ITERATOR_HPP_INCLUDED
 #define LUABIND_CRTP_ITERATOR_HPP_INCLUDED
 
-#include <iterator>
+#include <cstddef>
 
 namespace luabind {
 	namespace detail {
 
 		template< typename CRTP, typename Category, typename ValueType, typename ReferenceType = ValueType&, typename DifferenceType = ptrdiff_t >
-		class crtp_iterator :
-			public std::iterator<Category, ValueType, DifferenceType, ValueType*, ReferenceType >
+		class crtp_iterator
 		{
 		public:
-			using base_type = std::iterator<Category, ValueType, DifferenceType, ValueType*, ReferenceType >;
-
+			using iterator_category = Category;
+			using value_type        = ValueType;
+			using difference_type   = DifferenceType;
+			using pointer           = ValueType*;
+			using reference         = ReferenceType;
 
 			CRTP& operator++()
 			{
@@ -37,12 +39,12 @@ namespace luabind {
 				return !upcast().equal(rhs);
 			}
 
-			typename base_type::reference operator*()
+			reference operator*()
 			{
 				return upcast().dereference();
 			}
 
-			typename base_type::reference operator->()
+			reference operator->()
 			{
 				return upcast().dereference();
 			}


### PR DESCRIPTION
The `std::iterator` class was deprecated in C++17 but luckily replacing it is very simple.