### PR TITLE
fix: redefining `__cdecl` macro

### DIFF
--- a/luabind/config.hpp
+++ b/luabind/config.hpp
@@ -107,9 +107,12 @@
 #endif
 
 #ifndef _WIN32
-#include <cstddef>
-#define __cdecl
+# include <cstddef>
+# ifndef __cdecl
+#  define __cdecl
+# endif // __cdecl
 #endif // _WIN32
+
 #ifndef _FARQ
 #define _FARQ
 #endif // _FARQ


### PR DESCRIPTION
This actually happens in OpenXRay were we define `__cdecl` ourself and which gets overwritten here.